### PR TITLE
Update zmert.rb

### DIFF
--- a/MEMT/scripts/zmert/zmert.rb
+++ b/MEMT/scripts/zmert/zmert.rb
@@ -120,6 +120,7 @@ end
 
 def run_zmert(directory)
   Dir.chdir(directory + '/zmert') do
+    #the original "-maxMem" of Joshua ZMERT is 1000, if your RAM is large enough, I strongly suggested to set it as large as possible 
     command = escape_shell_array(["java", "-Xms1G", "-Xmx3G", "-cp", AVENUE_DIR + "/Utilities/scoring/meteor-1.0/dist/meteor-1.0/meteor.jar:" + AVENUE_DIR + "/Utilities/Tuning/zmert.jar", "joshua.zmert.ZMERT","-maxMem", "1000", "zmert_config.txt"])
     $stdout.puts "Running #{command}"
     #z-mert is buggy wrt , versus . otherwise


### PR DESCRIPTION
Remind users to adjust the -maxMem parameter of ZMERT, since MEMT might stop working when memory is limited, nbest and systems count are large. JRE will stop a process when there are too much GC actions.
